### PR TITLE
Fix issue #9 (negate_sequence bug)

### DIFF
--- a/info.py
+++ b/info.py
@@ -47,7 +47,7 @@ def negate_sequence(text):
             pprev = prev
         prev = negated
 
-        if any(neg in word for neg in ["not", "n't", "no"]):
+        if stripped in ["not", "cannot", "no"] or stripped.endswith("n't"):
             negation = not negation
 
         if any(c in word for c in delims):
@@ -59,7 +59,7 @@ def negate_sequence(text):
 def train():
     global pos, neg, totals
     retrain = False
-    
+
     # Load counts if they already exist.
     if not retrain and os.path.isfile(CDATA_FILE):
         pos, neg, totals = cPickle.load(open(CDATA_FILE))
@@ -74,12 +74,12 @@ def train():
         for word in set(negate_sequence(open("./aclImdb/train/neg/" + file).read())):
             neg[word] += 1
             pos['not_' + word] += 1
-    
+
     prune_features()
 
     totals[0] = sum(pos.values())
     totals[1] = sum(neg.values())
-    
+
     countdata = (pos, neg, totals)
     cPickle.dump(countdata, open(CDATA_FILE, 'w'))
 
@@ -104,7 +104,7 @@ def classify2(text):
 
 def classify_demo(text):
     words = set(word for word in negate_sequence(text) if word in pos or word in neg)
-    if (len(words) == 0): 
+    if (len(words) == 0):
         print "No features to compare on"
         return True
 


### PR DESCRIPTION
Please review my fix for issue #9.

I use the stripped version of the word (lowered and stripped of delims) to see if it equals `"not"`, `"cannot"`, `"no"`, or if it ends with `"n't"`. If any of these are true, then `negation` is negated.

This fixes both issues of:
1.  `negation` being changed when seeing words _containing_ `["no", "not", "n't"]` (e.g. `"know"`)
2.  `negation` not being changed when seeing things that are uppercase that should trigger `negation` being changed but don't. (i.e., capital `"DON'T"`)

I added the word `"cannot"` because if I checked `if stripped.endswith("not")` then that would match words like `"knot"` and `"whatnot"`. I'm assuming negation is wanted when observing the word `"cannot"`. If this is a wrong assumption please let me know.

Cheers,
@Sm1th
